### PR TITLE
Corrected rare deadlock condition on observable.as_blocking().subscribe()

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -196,8 +196,8 @@ class blocking_observable
         cs.add(
             [&](){
                 std::unique_lock<std::mutex> guard(lock);
-                wake.notify_one();
                 disposed = true;
+                wake.notify_one();
             });
 
         source.subscribe(std::move(scbr));


### PR DESCRIPTION
Previously flag was set after pinging the condition variable, so waiting thread could woke up before the flag was set, and then the thread entered sleep again since condition was not met (yet). The problem was, nothing ever woke this thread as the "cs" was already spent. On some platforms the threads could actually wake up due to https://en.wikipedia.org/wiki/Spurious_wakeup but that's not guaranteed to ever happen.